### PR TITLE
:tada: add custom page to show message subscription result.

### DIFF
--- a/mailjet-options.php
+++ b/mailjet-options.php
@@ -148,6 +148,23 @@ class WP_Mailjet_Options
                 get_option('mailjet_auto_subscribe_list_id'), __('Autosubscribe new users to this list', 'wp-mailjet'), FALSE, $lists);
         }
 
+
+        //custom page
+
+        // Pull all the pages into an array
+        $options_pages = array();
+        $options_pages_obj = get_pages();
+        //$options_pages[] = 'Select a page:';
+        foreach ($options_pages_obj as $page) {
+            //$options_pages[$page->ID] = $page->post_title;
+            $options_pages[] = array('value' => $page->ID, 'label' => $page->post_title);
+        }
+        $generalOptions[] = new WP_Mailjet_Options_Form_Option('mailjet_custom_page', '', 'select',
+            get_option('mailjet_custom_page'), __('Custom Page', 'wp-mailjet'), TRUE, $options_pages);
+
+        //end custom page
+
+
         $generalFieldset = new WP_Mailjet_Options_Form_Fieldset(
             __('General Settings', 'wp-mailjet'),
             $generalOptions,
@@ -225,6 +242,7 @@ class WP_Mailjet_Options
         $fields['mailjet_auto_subscribe_list_id'] = ($fields['mailjet_username'] != get_option('mailjet_username') || $fields['mailjet_password'] != get_option('mailjet_password'))
             ? false
             : strip_tags(filter_var($_POST['mailjet_auto_subscribe_list_id'], FILTER_SANITIZE_NUMBER_INT));
+        $fields['mailjet_custom_page'] = trim(strip_tags(filter_var($_POST['mailjet_custom_page'], FILTER_SANITIZE_STRING)));
         if (current_user_can('administrator')) {
             $fields['mailjet_access_editor'] = (isset($_POST['mailjet_access_editor']) ? 1 : 0);
             $fields['mailjet_access_author'] = (isset($_POST['mailjet_access_author']) ? 1 : 0);
@@ -262,6 +280,7 @@ class WP_Mailjet_Options
             update_option('mailjet_ssl', $fields['mailjet_ssl']);
             update_option('mailjet_port', $fields['mailjet_port']);
             update_option('mailjet_auto_subscribe_list_id', $fields['mailjet_auto_subscribe_list_id']);
+            update_option('mailjet_custom_page', $fields['mailjet_custom_page']);
             if (current_user_can('administrator')) {
                 update_option('mailjet_access_editor', $fields['mailjet_access_editor']);
                 update_option('mailjet_access_author', $fields['mailjet_access_author']);
@@ -324,7 +343,7 @@ class WP_Mailjet_Options
             // If there is connection, display successful message
             if ($connected !== FALSE) {
 
-                if(!$this->hasValidSender($from_email, $senders)) {
+                if (!$this->hasValidSender($from_email, $senders)) {
                     WP_Mailjet_Utils::custom_notice('error', __('Please make sure that you are using the correct API key and secret key associated to your mailjet account (from email).', 'wp-mailjet'));
                 }
                 // Record API and secret keys in WP DB only on successful connect

--- a/mailjet-utils.php
+++ b/mailjet-utils.php
@@ -3,15 +3,26 @@
 /**
  * Mailjet Wordpress Plugin
  *
- * @author		Mailjet
- * @link		http://www.mailjet.com/
+ * @author        Mailjet
+ * @link        http://www.mailjet.com/
  *
  */
-
 class WP_Mailjet_Utils
 {
-	public static function custom_notice($type, $message)
-	{
-		echo '<div class="' . $type . '"><p>' . $message . '</p></div>';
-	}
+    public static function custom_notice($type, $message)
+    {
+        echo '<div class="' . $type . '"><p>' . $message . '</p></div>';
+    }
+}
+
+/**
+ * Replace {{content}} in page to respective message
+ * @param $content
+ * @return mixed
+ */
+function mailjet_custom_page_content_filter($content)
+{
+    $text = str_replace(array('%content%', '{{content}}'), $content, $GLOBALS["mailjet_msg"]);
+    return $text;
+
 }

--- a/mailjet-widget.php
+++ b/mailjet-widget.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Mailjet Wordpress Plugin
  *
@@ -58,7 +59,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         foreach ($this->langs as $lang => $langProps) {
             $fileHandler = new FileHandler(dirname(__FILE__) . '/i18n/wp-mailjet-subscription-widget-' . $langProps['locale'] . '.po');
             $this->{'poParser' . $lang} = new PoParser($fileHandler);
-            $this->{'entries' . $lang}  = $this->{'poParser' . $lang}->parse();
+            $this->{'entries' . $lang} = $this->{'poParser' . $lang}->parse();
         }
 
         // if user clicks on the email confirm subscription link, verify the token and subscribe them
@@ -122,13 +123,13 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         global $WPMailjet;
 
         // if there are translation entries in the POST, update them
-        if($this->preg_array_key_exists('/msgstr/', $_POST)){
+        if ($this->preg_array_key_exists('/msgstr/', $_POST)) {
             require_once(dirname(__FILE__) . '/libs/php.mo-master/php-mo.php');
             foreach ($this->langs as $lang => $locale) {
-                foreach($_POST as $key => $value) {
-                    if(substr($key, 0, 7) === 'msgstr-'){
-                        foreach($this->{'entries' . $lang} as $entryKey => $entryValue){
-                            if($this->entryStrToId($entryKey) === str_replace('msgstr-' . $lang . '-', '', $key)){
+                foreach ($_POST as $key => $value) {
+                    if (substr($key, 0, 7) === 'msgstr-') {
+                        foreach ($this->{'entries' . $lang} as $entryKey => $entryValue) {
+                            if ($this->entryStrToId($entryKey) === str_replace('msgstr-' . $lang . '-', '', $key)) {
                                 $this->{'entries' . $lang}[$entryKey]['msgstr'][0] = stripcslashes($_POST[$key]);
                                 $this->{'poParser' . $lang}->setEntry($entryKey, $this->{'entries' . $lang}[$entryKey]);
                             }
@@ -141,7 +142,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
                 phpmo_convert(dirname(__FILE__) . '/i18n/wp-mailjet-subscription-widget-' . $locale['locale'] . '.po');
             }
             if (in_array(get_locale(), array('en_US', 'en_EN', ''))) {
-                foreach(array('-en_US', '-en_EN', '') as $lang) {
+                foreach (array('-en_US', '-en_EN', '') as $lang) {
                     $this->poParseren->writeFile(dirname(__FILE__) . '/i18n/wp-mailjet-subscription-widget' . $lang . '.po');
                     phpmo_convert(dirname(__FILE__) . '/i18n/wp-mailjet-subscription-widget' . $lang . '.po');
                 }
@@ -154,223 +155,263 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         foreach ($fields as $prop) {
             ${$prop} = empty($instance[$prop]) ? '' : $instance[$prop];
         }
-        foreach($langFields as $prop){
-            foreach($this->langs as $lang => $langProps){
+        foreach ($langFields as $prop) {
+            foreach ($this->langs as $lang => $langProps) {
                 ${$prop . $lang} = empty($instance[$prop . $lang]) ? '' : $instance[$prop . $lang];
             }
         }
 
         ?>
         <div class="mailjet-widget-container">
-        <div class="mj-accordion">
-            <h3>Step 1 - Choose up to 3 contact properties</h3>
-            <div>
-                <?php
-                $contactMetaProperties = $this->getContactMetaProperties();
-                if ($this->_userVersion === 3): ?>
-                <?php
-                if (empty($contactMetaProperties->Data)): ?>
-                    <div class="fontSizeSmall noProperties"><?php echo sprintf('No contact properties have been defined yet. Please create one by clicking on "Add New Property" below or by logging into your Mailjet account.'); ?></div>
-                    <div class="fontSizeSmall yesProperties" style="display:none;"><?php echo sprintf('Drag and drop up to %d contact properties from "Available contact properties" to "Selected contact properties" (besides email which is mandatory).', self::MAX_META_PROPERTIES); ?></div>
-                    <div class="label yesProperties" style="display:none;">Available contact properties</div>
-                <?php else: ?>
-                    <div class="fontSizeSmall yesProperties"><?php echo sprintf('Drag and drop up to %d contact properties from "Available contact properties" to "Selected contact properties" (besides email which is mandatory).', self::MAX_META_PROPERTIES); ?></div>
-                    <div class="label">Available contact properties</div>
-                <?php endif; ?>
-                <div class="sortable" <?php  if (empty($contactMetaProperties->Data)): ?> style="display:none;"  <?php endif; ?> >
-                    <div>
-                        <ul class="connectedSortable sortable1">
-                            <?php foreach ($contactMetaProperties->Data as $prop):
-                                $lang = 'en';
-                                    //foreach($this->langs as $lang => $langProps): ?>
+            <div class="mj-accordion">
+                <h3>Step 1 - Choose up to 3 contact properties</h3>
+                <div>
+                    <?php
+                    $contactMetaProperties = $this->getContactMetaProperties();
+                    if ($this->_userVersion === 3): ?>
+                        <?php
+                        if (empty($contactMetaProperties->Data)): ?>
+                            <div
+                                class="fontSizeSmall noProperties"><?php echo sprintf('No contact properties have been defined yet. Please create one by clicking on "Add New Property" below or by logging into your Mailjet account.'); ?></div>
+                            <div class="fontSizeSmall yesProperties"
+                                 style="display:none;"><?php echo sprintf('Drag and drop up to %d contact properties from "Available contact properties" to "Selected contact properties" (besides email which is mandatory).', self::MAX_META_PROPERTIES); ?></div>
+                            <div class="label yesProperties" style="display:none;">Available contact properties</div>
+                        <?php else: ?>
+                            <div
+                                class="fontSizeSmall yesProperties"><?php echo sprintf('Drag and drop up to %d contact properties from "Available contact properties" to "Selected contact properties" (besides email which is mandatory).', self::MAX_META_PROPERTIES); ?></div>
+                            <div class="label">Available contact properties</div>
+                        <?php endif; ?>
+                        <div
+                            class="sortable" <?php if (empty($contactMetaProperties->Data)): ?> style="display:none;"  <?php endif; ?> >
+                            <div>
+                                <ul class="connectedSortable sortable1">
+                                    <?php foreach ($contactMetaProperties->Data as $prop):
+                                        $lang = 'en';
+                                        //foreach($this->langs as $lang => $langProps):
+                                        ?>
                                         <?php if (!in_array($prop->Name, array(${'metaPropertyName1' . $lang}, ${'metaPropertyName2' . $lang}, ${'metaPropertyName3' . $lang}))): ?>
-                                            <li class="ui-state-default"><div class="cursorMoveImg"></div>&nbsp;&nbsp;&nbsp;&nbsp;<?php echo $prop->Name; ?></li>
-                                        <?php endif; ?>
-                                    <?php //endforeach; ?>
-                            <?php endforeach; ?>
-                        </ul>
-                    </div>
-                    <div>
-                        <div class="label">Selected properties</div>
-                        <div class="fontSizeSmall">Arrange and sort the properties you selected to determine the way they will be shown in the widget.</div>
-                        <ul class="connectedSortable sortable2">
-                            <li class="ui-state-disabled">Email address (mandatory)</li>
-                            <?php $selectedProps = array();
-                                foreach ($instance as $prop):
-                                    if (empty($prop) || in_array($prop, $selectedProps)) {
-                                        continue;
-                                    }
-                                    $lang = 'en'; ?>
-                                    <?php if (in_array($prop, array(${'metaPropertyName1' . $lang}, ${'metaPropertyName2' . $lang}, ${'metaPropertyName3' . $lang}))): ?>
-                                        <li class="ui-state-default"><div class="cursorMoveImg"></div>&nbsp;&nbsp;&nbsp;&nbsp;<?php echo $prop; ?></li>
+                                        <li class="ui-state-default">
+                                            <div class="cursorMoveImg"></div>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;<?php echo $prop->Name; ?></li>
+                                    <?php endif; ?>
+                                        <?php //endforeach;
+                                        ?>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                            <div>
+                                <div class="label">Selected properties</div>
+                                <div class="fontSizeSmall">Arrange and sort the properties you selected to determine the
+                                    way they will be shown in the widget.
+                                </div>
+                                <ul class="connectedSortable sortable2">
+                                    <li class="ui-state-disabled">Email address (mandatory)</li>
+                                    <?php $selectedProps = array();
+                                    foreach ($instance as $prop):
+                                        if (empty($prop) || in_array($prop, $selectedProps)) {
+                                            continue;
+                                        }
+                                        $lang = 'en'; ?>
+                                        <?php if (in_array($prop, array(${'metaPropertyName1' . $lang}, ${'metaPropertyName2' . $lang}, ${'metaPropertyName3' . $lang}))): ?>
+                                        <li class="ui-state-default">
+                                            <div class="cursorMoveImg"></div>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;<?php echo $prop; ?></li>
                                         <?php $selectedProps[] = $prop; ?>
                                     <?php endif; ?>
-                            <?php endforeach; ?>
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="new-meta-contact-form">
-                    <div class="label">Add New Property</div>
-                    <div>Click on the button below to dynamically add a new contact property to your contact list and widget.</div>
-                    <ul class="newPropertyBtn">
-                        <li>Add a new property</li>
-                    </ul>
-                    <?php if (isset($metaAdded)): ?>
-                        <div class="success">Property created. Please drag your new contact property to the Selected Properties section above.</div>
-                    <?php endif; ?>
-                    <div class="newPropertyForm ninja">
-                        <div class="new-meta-property-response"></div>
-                        <div>
-                            <label>Name</label><br/>
-                            <input type="text" name="new_meta_name" class="new_meta_name"
-                                title="Please make sure you are not using forbidden characters: , * + - / &quot; ' : [ ] ( ) > < = ; $"/>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
                         </div>
-                        <div>
-                            <label>Contact property type</label><br/>
-                            <select name="new_meta_data_type" class="new_meta_data_type">
-                                <option value="str">String (ex. FirstName)</option>
-                                <option value="int">Integer (ex. 90210)</option>
-                                <option value="float">Decimal (ex. 6245.538)</option>
-                                <option value="bool">Bool</option>
-                            </select>
-                        </div>
-                        <p>
-                            <input type="submit" name="submit" class="button new-meta-submit" value="Add"/>
-                            <input name="action" type="hidden" value="mailjet_subscribe_ajax_add_meta_property"/>
-                        </p>
-                    </div>
-                </div>
-                    <?php endif; ?>
-                <p>
-                    <input type="submit" class="next floatRight button" value="Next"/>
-                </p>
-            </div>
 
-            <h3>Step 2 - Define your widget labels</h3>
-            <div>
-                <div class="mj-tabs-container">
-                    <ul class="mj-tabs-menu">
-                        <?php foreach ($this->langs as $lang => $langProps): ?>
-                            <li class="<?php echo $lang === 'en' ? 'current' : ''; ?>">
-                                <a href=".tab-<?php echo $lang; ?>"><?php echo $langProps['label']; ?></a>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                    <div class="mj-tab">
-                        <?php foreach ($this->langs as $lang => $langProps): ?>
-                            <div class="mj-tab-content tab-<?php echo $lang; ?>">
-                                <div class="tabActivator<?php echo $lang === 'en' ? ' ninja' : ''; ?>" id="<?php echo $this->get_field_id('tabActivator-' . $lang); ?>">
-                                    <input type="checkbox" name="<?php echo $this->get_field_name('enableTab' . $lang); ?>"
-                                           class="enable-tab enable-tab-<?php echo $lang; ?>" id="<?php echo $this->get_field_id('enableTab' . $lang); ?>"
-                                           <?php echo $lang === 'en' ? 'checked="checked"' :
-                                               (empty(${'enableTab'.$lang}) ? '' : 'checked="checked"'); ?> />
-                                    <label for="<?php echo $this->get_field_id('enableTab' . $lang); ?>">Activate tab</label>
+                        <div class="new-meta-contact-form">
+                            <div class="label">Add New Property</div>
+                            <div>Click on the button below to dynamically add a new contact property to your contact
+                                list and widget.
+                            </div>
+                            <ul class="newPropertyBtn">
+                                <li>Add a new property</li>
+                            </ul>
+                            <?php if (isset($metaAdded)): ?>
+                                <div class="success">Property created. Please drag your new contact property to the
+                                    Selected Properties section above.
                                 </div>
-                                <!-- This element will be populated with input text fields for each selected meta property -->
-                                <div class="fontSizeSmall">Please enter specific labels for your subscription widget and they
-                                    will be displayed on the front end of your website.</div>
-                                <?php if ($this->_userVersion === 3): ?>
-                                    <div class="clear map-meta-properties">
-                                    <?php for($i = 1; $i <= 3; $i++): ?>
-                                        <div class="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>">
-                                            <label for="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>"><?php
-                                                echo esc_attr(${'metaPropertyName' . $i . $lang}); ?></label>
-                                            <input type="hidden" id="<?php echo $this->get_field_id('metaPropertyName' . $i . $lang); ?>"
-                                                name="<?php echo $this->get_field_name('metaPropertyName' . $i . $lang); ?>"
-                                                value="<?php echo esc_attr(${'metaPropertyName' . $i . $lang}); ?>" />
-                                            <input class="widefat"
-                                                id="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>"
-                                                name="<?php echo $this->get_field_name('metaProperty' . $i . $lang); ?>"
-                                                type="text"
-                                                value="<?php echo empty(${'metaProperty' . $i . $lang}) ? '' : esc_attr(${'metaProperty' . $i . $lang}); ?>"
-                                                size="28" />
-                                        </div>
-                                    <?php endfor; ?>
-                                    </div>
-                                <?php endif; ?>
+                            <?php endif; ?>
+                            <div class="newPropertyForm ninja">
+                                <div class="new-meta-property-response"></div>
+                                <div>
+                                    <label>Name</label><br/>
+                                    <input type="text" name="new_meta_name" class="new_meta_name"
+                                           title="Please make sure you are not using forbidden characters: , * + - / &quot; ' : [ ] ( ) > < = ; $"/>
+                                </div>
+                                <div>
+                                    <label>Contact property type</label><br/>
+                                    <select name="new_meta_data_type" class="new_meta_data_type">
+                                        <option value="str">String (ex. FirstName)</option>
+                                        <option value="int">Integer (ex. 90210)</option>
+                                        <option value="float">Decimal (ex. 6245.538)</option>
+                                        <option value="bool">Bool</option>
+                                    </select>
+                                </div>
                                 <p>
-                                    <label for="<?php echo $this->get_field_id('title' . $lang); ?>"
-                                        title="This is the title of your subscription widget which will be displayed on your website">Title:
-                                        <input class="widefat" id="<?php echo $this->get_field_id('title' . $lang); ?>"
-                                            name="<?php echo $this->get_field_name('title' . $lang); ?>" type="text"
-                                            value="<?php echo esc_attr(${'title' . $lang}); ?>"/>
-                                    </label>
-                                </p>
-                                <p>
-                                    <label for="<?php echo $this->get_field_id('button_text' . $lang); ?>"
-                                        title="This will be the label of your subscription button which will be displayed on your website">Button text
-                                        <input class="widefat" id="<?php echo $this->get_field_id('button_text' . $lang); ?>"
-                                            name="<?php echo $this->get_field_name('button_text' . $lang); ?>" type="text"
-                                            value="<?php echo esc_attr(${'button_text' . $lang}); ?>"/>
-                                    </label>
-                                </p>
-                                <p>
-                                    <label for="<?php echo $this->get_field_id('list_id' . $lang); ?>"
-                                        title="Please chose a contact list where all new subscribers will be added">List:
-                                        <select class="widefat" <?php echo (isset($_POST) && count($_POST) > 0 && !is_numeric(${'list_id' . $lang})) ?
-                                            'style="border:1px solid red;' : '' ?> id="<?php echo $this->get_field_id('list_id' . $lang); ?>"
-                                            name="<?php echo $this->get_field_name('list_id' . $lang); ?>">
-                                            <?php foreach ($this->getLists() as $list) { ?>
-                                                <option value="<?php echo $list['value'] ?>"<?php echo($list['value'] == esc_attr(${'list_id' . $lang}) ?
-                                                    ' selected="selected"' : '') ?>><?php echo $list['label'] ?></option>
-                                            <?php } ?>
-                                        </select>
-                                    </label>
+                                    <input type="submit" name="submit" class="button new-meta-submit" value="Add"/>
+                                    <input name="action" type="hidden"
+                                           value="mailjet_subscribe_ajax_add_meta_property"/>
                                 </p>
                             </div>
-                        <?php endforeach; ?>
-                    </div>
+                        </div>
+                    <?php endif; ?>
                     <p>
-                        <input type="submit" class="previous button" value="Back"/>
                         <input type="submit" class="next floatRight button" value="Next"/>
                     </p>
                 </div>
-            </div>
 
-            <h3>Step 3 - Customize your widget notifications</h3>
-            <div>
-                <div class="mj-tabs-container">
-                    <ul class="mj-tabs-menu">
-                        <?php foreach ($this->langs as $lang => $langProps): ?>
-                            <li class="<?php echo $lang === 'en' ? 'current' : ''; ?>">
-                                <a href=".tab-<?php echo $lang; ?>"><?php echo $langProps['label']; ?></a>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                    <div class="mj-tab">
-                        <?php foreach ($this->langs as $lang => $langProps): ?>
-                        <div class="mj-tab-content tab-<?=$lang?>">
-                            <div class="mj-translations-title margin-top-bottom-10 arrow_box" id="mj-translations-title-<?=$lang?>">
-                                <div style="display:none;">Widget notifications for this language are deactivated in previous step</div>
-                                <a id="<?php echo $this->get_field_id('tabLinkStep3-' . $lang); ?>" href="javascript:">Customize your widget notifications</a></div>
-                            <div class="mj-string-translations" id="<?php echo $this->get_field_id('mj-string-translations-' . $lang); ?>">
-                                <?php
-                                $i = 0;
-                                foreach ($this->{'entries' . $lang} as $msgid => $msg):
-                                    $id = $this->entryStrToId($msgid);
-                                    $i++;
-                                    if($i === 1):
-                                ?>
-                                    <h4>Errors/Website notifications</h4>
-                                    <!--The 1st 10 messages are for website notifications, the rest are for the email-->
-                                    <?php elseif($i === 10): ?>
-                                        <h4>Subscription confirmation mail</h4>
-                                    <?php endif; ?>
-                                    <div class="mj-translation-entry">
-                                        <h6><?php echo $msgid; ?></h6>
-                                            <textarea name="msgstr-<?php echo $lang; ?>-<?php echo $id; ?>" id="msgstr-<?php echo $lang; ?>-<?php echo $id; ?>"
-                                                rows="5" cols="30"><?php echo $msg['msgstr'][0]; ?></textarea>
+                <h3>Step 2 - Define your widget labels</h3>
+                <div>
+                    <div class="mj-tabs-container">
+                        <ul class="mj-tabs-menu">
+                            <?php foreach ($this->langs as $lang => $langProps): ?>
+                                <li class="<?php echo $lang === 'en' ? 'current' : ''; ?>">
+                                    <a href=".tab-<?php echo $lang; ?>"><?php echo $langProps['label']; ?></a>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <div class="mj-tab">
+                            <?php foreach ($this->langs as $lang => $langProps): ?>
+                                <div class="mj-tab-content tab-<?php echo $lang; ?>">
+                                    <div class="tabActivator<?php echo $lang === 'en' ? ' ninja' : ''; ?>"
+                                         id="<?php echo $this->get_field_id('tabActivator-' . $lang); ?>">
+                                        <input type="checkbox"
+                                               name="<?php echo $this->get_field_name('enableTab' . $lang); ?>"
+                                               class="enable-tab enable-tab-<?php echo $lang; ?>"
+                                               id="<?php echo $this->get_field_id('enableTab' . $lang); ?>"
+                                            <?php echo $lang === 'en' ? 'checked="checked"' :
+                                                (empty(${'enableTab' . $lang}) ? '' : 'checked="checked"'); ?> />
+                                        <label for="<?php echo $this->get_field_id('enableTab' . $lang); ?>">Activate
+                                            tab</label>
                                     </div>
-                                <?php endforeach; ?>
-                            </div>
+                                    <!-- This element will be populated with input text fields for each selected meta property -->
+                                    <div class="fontSizeSmall">Please enter specific labels for your subscription widget
+                                        and they
+                                        will be displayed on the front end of your website.
+                                    </div>
+                                    <?php if ($this->_userVersion === 3): ?>
+                                        <div class="clear map-meta-properties">
+                                            <?php for ($i = 1; $i <= 3; $i++): ?>
+                                                <div
+                                                    class="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>">
+                                                    <label
+                                                        for="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>"><?php
+                                                        echo esc_attr(${'metaPropertyName' . $i . $lang}); ?></label>
+                                                    <input type="hidden"
+                                                           id="<?php echo $this->get_field_id('metaPropertyName' . $i . $lang); ?>"
+                                                           name="<?php echo $this->get_field_name('metaPropertyName' . $i . $lang); ?>"
+                                                           value="<?php echo esc_attr(${'metaPropertyName' . $i . $lang}); ?>"/>
+                                                    <input class="widefat"
+                                                           id="<?php echo $this->get_field_id('metaProperty' . $i . $lang); ?>"
+                                                           name="<?php echo $this->get_field_name('metaProperty' . $i . $lang); ?>"
+                                                           type="text"
+                                                           value="<?php echo empty(${'metaProperty' . $i . $lang}) ? '' : esc_attr(${'metaProperty' . $i . $lang}); ?>"
+                                                           size="28"/>
+                                                </div>
+                                            <?php endfor; ?>
+                                        </div>
+                                    <?php endif; ?>
+                                    <p>
+                                        <label for="<?php echo $this->get_field_id('title' . $lang); ?>"
+                                               title="This is the title of your subscription widget which will be displayed on your website">Title:
+                                            <input class="widefat"
+                                                   id="<?php echo $this->get_field_id('title' . $lang); ?>"
+                                                   name="<?php echo $this->get_field_name('title' . $lang); ?>"
+                                                   type="text"
+                                                   value="<?php echo esc_attr(${'title' . $lang}); ?>"/>
+                                        </label>
+                                    </p>
+                                    <p>
+                                        <label for="<?php echo $this->get_field_id('button_text' . $lang); ?>"
+                                               title="This will be the label of your subscription button which will be displayed on your website">Button
+                                            text
+                                            <input class="widefat"
+                                                   id="<?php echo $this->get_field_id('button_text' . $lang); ?>"
+                                                   name="<?php echo $this->get_field_name('button_text' . $lang); ?>"
+                                                   type="text"
+                                                   value="<?php echo esc_attr(${'button_text' . $lang}); ?>"/>
+                                        </label>
+                                    </p>
+                                    <p>
+                                        <label for="<?php echo $this->get_field_id('list_id' . $lang); ?>"
+                                               title="Please chose a contact list where all new subscribers will be added">List:
+                                            <select
+                                                class="widefat" <?php echo (isset($_POST) && count($_POST) > 0 && !is_numeric(${'list_id' . $lang})) ?
+                                                'style="border:1px solid red;' : '' ?>
+                                                id="<?php echo $this->get_field_id('list_id' . $lang); ?>"
+                                                name="<?php echo $this->get_field_name('list_id' . $lang); ?>">
+                                                <?php foreach ($this->getLists() as $list) { ?>
+                                                    <option
+                                                        value="<?php echo $list['value'] ?>"<?php echo($list['value'] == esc_attr(${'list_id' . $lang}) ?
+                                                        ' selected="selected"' : '') ?>><?php echo $list['label'] ?></option>
+                                                <?php } ?>
+                                            </select>
+                                        </label>
+                                    </p>
+                                </div>
+                            <?php endforeach; ?>
                         </div>
-                         <?php endforeach; ?>
+                        <p>
+                            <input type="submit" class="previous button" value="Back"/>
+                            <input type="submit" class="next floatRight button" value="Next"/>
+                        </p>
                     </div>
-                    <p><input type="submit" class="previous button" value="Back"/></p>
+                </div>
+
+                <h3>Step 3 - Customize your widget notifications</h3>
+                <div>
+                    <div class="mj-tabs-container">
+                        <ul class="mj-tabs-menu">
+                            <?php foreach ($this->langs as $lang => $langProps): ?>
+                                <li class="<?php echo $lang === 'en' ? 'current' : ''; ?>">
+                                    <a href=".tab-<?php echo $lang; ?>"><?php echo $langProps['label']; ?></a>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <div class="mj-tab">
+                            <?php foreach ($this->langs as $lang => $langProps): ?>
+                                <div class="mj-tab-content tab-<?= $lang ?>">
+                                    <div class="mj-translations-title margin-top-bottom-10 arrow_box"
+                                         id="mj-translations-title-<?= $lang ?>">
+                                        <div style="display:none;">Widget notifications for this language are
+                                            deactivated in previous step
+                                        </div>
+                                        <a id="<?php echo $this->get_field_id('tabLinkStep3-' . $lang); ?>"
+                                           href="javascript:">Customize your widget notifications</a></div>
+                                    <div class="mj-string-translations"
+                                         id="<?php echo $this->get_field_id('mj-string-translations-' . $lang); ?>">
+                                        <?php
+                                        $i = 0;
+                                        foreach ($this->{'entries' . $lang} as $msgid => $msg):
+                                            $id = $this->entryStrToId($msgid);
+                                            $i++;
+                                            if ($i === 1):
+                                                ?>
+                                                <h4>Errors/Website notifications</h4>
+                                                <!--The 1st 10 messages are for website notifications, the rest are for the email-->
+                                            <?php elseif ($i === 10): ?>
+                                                <h4>Subscription confirmation mail</h4>
+                                            <?php endif; ?>
+                                            <div class="mj-translation-entry">
+                                                <h6><?php echo $msgid; ?></h6>
+                                            <textarea name="msgstr-<?php echo $lang; ?>-<?php echo $id; ?>"
+                                                      id="msgstr-<?php echo $lang; ?>-<?php echo $id; ?>"
+                                                      rows="5" cols="30"><?php echo $msg['msgstr'][0]; ?></textarea>
+                                            </div>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                        <p><input type="submit" class="previous button" value="Back"/></p>
+                    </div>
                 </div>
             </div>
-        </div>
         </div>
         <?php if (isset($_POST) && count($_POST) > 0): ?>
         <div class="mailjet_subscribe_response"><?php
@@ -394,7 +435,8 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
      * @param string $input
      * @return bool
      */
-    function mj_is_int($input) {
+    function mj_is_int($input)
+    {
         return ctype_digit(strval($input));
     }
 
@@ -403,7 +445,8 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
      * @param string $input
      * @return bool
      */
-    function mj_is_float($input) {
+    function mj_is_float($input)
+    {
         return $input === (string)(float)$input;
     }
 
@@ -412,7 +455,8 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
      * @param string $input
      * @return bool
      */
-    function mj_is_bool($input) {
+    function mj_is_bool($input)
+    {
         return in_array(strtolower($input), array('1', 't', 'true', 'y', '0', 'f', 'false', 'n'));
     }
 
@@ -465,7 +509,8 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
                         continue;
                     }
                     if ($accountProperty->Name === $submittedProperty &&
-                        $this->$dataTypes[$accountProperty->Datatype]($_POST[$submittedProperty]) !== true) {
+                        $this->$dataTypes[$accountProperty->Datatype]($_POST[$submittedProperty]) !== true
+                    ) {
                         $error = 'You have entered a contact property with wrong data type, for example a string instead of a number.';
                     }
                 }
@@ -476,13 +521,20 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
             }
         }
 
+        //custom page
+        if (get_option('mailjet_custom_page')) {
+            $custom_page = get_page_link(get_option('mailjet_custom_page'));
+        } else {
+            $custom_page = get_site_url();
+        }
+
         $params = http_build_query($_POST);
         $message = file_get_contents(dirname(__FILE__) . '/templates/confirm-subscription-email.php');
         $emailParams = array(
             '__EMAIL_TITLE__' => __('Confirm your mailing list subscription', 'wp-mailjet-subscription-widget'),
             '__EMAIL_HEADER__' => __('Please Confirm Your Subscription To', 'wp-mailjet-subscription-widget'),
             '__WP_URL__' => sprintf('<a href="%s" target="_blank">%s</a>', get_site_url(), get_site_url()),
-            '__CONFIRM_URL__' => get_site_url() . '?' . $params . '&mj_sub_token=' . sha1($params . self::WIDGET_HASH),
+            '__CONFIRM_URL__' => $custom_page . '?' . $params . '&mj_sub_token=' . sha1($params . self::WIDGET_HASH),
             '__CLICK_HERE__' => __('Click here to confirm', 'wp-mailjet-subscription-widget'),
             '__COPY_PASTE_LINK__' => __('You may copy/paste this link into your browser:', 'wp-mailjet-subscription-widget'),
             '__FROM_NAME__' => get_option('blogname'),
@@ -505,14 +557,28 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
      */
     function subscribeUser()
     {
+        //determinate if have valid custom page
+        $show_custom_page = false;
+        if (get_option('mailjet_custom_page')) {
+            add_filter('the_content', 'mailjet_custom_page_content_filter');
+            $show_custom_page = true;
+        }
+        $msg = '';
+
         // validate token
         $mj_sub_token = $_GET['mj_sub_token'];
         unset($_GET['mj_sub_token']);
         if (sha1(http_build_query($_GET) . self::WIDGET_HASH) !== $mj_sub_token) {
-            echo '<p class="error" listId="' . $_GET['list_id'] . '">';
-            echo __('Error. Token verification failed.', 'wp-mailjet-subscription-widget');
-            echo '</p>';
-            die;
+            $msg .= '<p class="error" listId="' . $_GET['list_id'] . '">';
+            $msg .= __('Error. Token verification failed.', 'wp-mailjet-subscription-widget');
+            $msg .= '</p>';
+            if ($show_custom_page) {
+                $GLOBALS["mailjet_msg"] = $msg;
+                return;
+            } else {
+                echo $msg;
+                die;
+            }
         }
 
         $email = $_GET['email'];
@@ -549,19 +615,25 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         // Check what is the response and display proper message
         if (isset($result->Status)) {
             if ($result->Status == 'DUPLICATE') {
-                echo '<p class="error" listId="' . $_GET['list_id'] . '">';
-                echo sprintf(__("The contact %s is already subscribed", 'wp-mailjet-subscription-widget'), $email);
-                echo '</p>';
+                $msg .= '<p class="error" listId="' . $_GET['list_id'] . '">';
+                $msg .= sprintf(__("The contact %s is already subscribed", 'wp-mailjet-subscription-widget'), $email);
+                $msg .= '</p>';
             } else if ($result->Status == 'OK') {
-                echo '<p class="success" listId="' . $_GET['list_id'] . '">';
-                echo sprintf(__("Thanks for subscribing with %s", 'wp-mailjet-subscription-widget'), $email);
-                echo '</p>';
+                $msg .= '<p class="success" listId="' . $_GET['list_id'] . '">';
+                $msg .= sprintf(__("Thanks for subscribing with %s", 'wp-mailjet-subscription-widget'), $email);
+                $msg .= '</p>';
             } else {
-                echo '<p class="error" listId="' . $_GET['list_id'] . '">';
-                echo sprintf(__("The contact %s is already subscribed", 'wp-mailjet-subscription-widget'), $email);
-                echo '</p>';
+                $msg .= '<p class="error" listId="' . $_GET['list_id'] . '">';
+                $msg .= sprintf(__("The contact %s is already subscribed", 'wp-mailjet-subscription-widget'), $email);
+                $msg .= '</p>';
             }
-            die();
+            if ($show_custom_page) {
+                $GLOBALS["mailjet_msg"] = $msg;
+                return;
+            } else {
+                echo $msg;
+                die();
+            }
         }
     }
 
@@ -584,12 +656,12 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
 
         $langFields = array('enableTab', 'title', 'list_id', 'button_text', 'metaPropertyName1', 'metaPropertyName2',
             'metaPropertyName3', 'metaProperty1', 'metaProperty2', 'metaProperty3');
-        if(isset($fields) && is_array($fields))
-        foreach($fields as $prop){
-            ${$prop} = empty($instance[$prop]) ? '' : $instance[$prop];
-        }
+        if (isset($fields) && is_array($fields))
+            foreach ($fields as $prop) {
+                ${$prop} = empty($instance[$prop]) ? '' : $instance[$prop];
+            }
 
-        foreach($this->langs as $lang => $langProps) {
+        foreach ($this->langs as $lang => $langProps) {
             if (get_locale() !== $langProps['locale']) {
                 continue;
             }
@@ -599,7 +671,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         // if the widget is not configured for the current WP language, the English widget configuration is taken
         $currentLang = empty($currentLang) ? 'en' : $currentLang;
 
-        foreach($langFields as $prop){
+        foreach ($langFields as $prop) {
             if (!empty($instance[$prop . $currentLang])) {
                 ${$prop . $currentLang} = $instance[$prop . $currentLang];
             }
@@ -622,13 +694,16 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         <form class="subscribe-form">
             <?php if ($this->_userVersion === 3): ?>
                 <?php if (!empty(${'metaProperty1' . $currentLang})): ?>
-                    <input name="<?php echo ${'metaPropertyName1' . $currentLang}; ?>" type="text" placeholder="<?php echo ${'metaProperty1' . $currentLang}; ?>"/>
+                    <input name="<?php echo ${'metaPropertyName1' . $currentLang}; ?>" type="text"
+                           placeholder="<?php echo ${'metaProperty1' . $currentLang}; ?>"/>
                 <?php endif; ?>
                 <?php if (!empty(${'metaProperty2' . $currentLang})): ?>
-                    <input name="<?php echo ${'metaPropertyName2' . $currentLang}; ?>" type="text" placeholder="<?php echo ${'metaProperty2' . $currentLang}; ?>"/>
+                    <input name="<?php echo ${'metaPropertyName2' . $currentLang}; ?>" type="text"
+                           placeholder="<?php echo ${'metaProperty2' . $currentLang}; ?>"/>
                 <?php endif; ?>
                 <?php if (!empty(${'metaProperty3' . $currentLang})): ?>
-                    <input name="<?php echo ${'metaPropertyName3' . $currentLang}; ?>" type="text" placeholder="<?php echo ${'metaProperty3' . $currentLang}; ?>"/>
+                    <input name="<?php echo ${'metaPropertyName3' . $currentLang}; ?>" type="text"
+                           placeholder="<?php echo ${'metaProperty3' . $currentLang}; ?>"/>
                 <?php endif; ?>
             <?php endif; ?>
 

--- a/mailjet-widget.php
+++ b/mailjet-widget.php
@@ -150,7 +150,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         }
 
         $fields = array('new_meta_name', 'new_meta_data_type');
-        $langFields = array('enableTab', 'title', 'list_id', 'button_text', 'metaPropertyName1', 'metaPropertyName2',
+        $langFields = array('enableTab', 'title', 'list_id', 'button_text', 'button_class', 'metaPropertyName1', 'metaPropertyName2',
             'metaPropertyName3', 'metaProperty1', 'metaProperty2', 'metaProperty3');
         foreach ($fields as $prop) {
             ${$prop} = empty($instance[$prop]) ? '' : $instance[$prop];
@@ -337,6 +337,19 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
                                                    value="<?php echo esc_attr(${'button_text' . $lang}); ?>"/>
                                         </label>
                                     </p>
+
+                                    <p>
+                                        <label for="<?php echo $this->get_field_id('button_class' . $lang); ?>"
+                                               title="This will be the css class of your subscription button which will be displayed on your website">Button
+                                            text
+                                            <input class="widefat"
+                                                   id="<?php echo $this->get_field_id('button_class' . $lang); ?>"
+                                                   name="<?php echo $this->get_field_name('button_class' . $lang); ?>"
+                                                   type="text"
+                                                   value="<?php echo esc_attr(${'button_class' . $lang}); ?>"/>
+                                        </label>
+                                    </p>
+
                                     <p>
                                         <label for="<?php echo $this->get_field_id('list_id' . $lang); ?>"
                                                title="Please chose a contact list where all new subscribers will be added">List:
@@ -654,7 +667,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
 
         echo $before_widget;
 
-        $langFields = array('enableTab', 'title', 'list_id', 'button_text', 'metaPropertyName1', 'metaPropertyName2',
+        $langFields = array('enableTab', 'title', 'list_id', 'button_text', 'button_class', 'metaPropertyName1', 'metaPropertyName2',
             'metaPropertyName3', 'metaProperty1', 'metaProperty2', 'metaProperty3');
         if (isset($fields) && is_array($fields))
             foreach ($fields as $prop) {
@@ -680,6 +693,7 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
         $title = apply_filters('widget_title', $instance['title' . $currentLang]);
         $list_id = $instance['list_id' . $currentLang];
         $button_text = trim($instance['button_text' . $currentLang]);
+        $button_class = trim($instance['button_class' . $currentLang]);
 
         // If contact list is not selected then we just don't display the widget!
         if (!is_numeric($list_id)) {
@@ -711,7 +725,8 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
                    placeholder="<?php _e('your@email.com', 'wp-mailjet-subscription-widget'); ?>"/>
             <input name="list_id" type="hidden" value="<?php echo $list_id; ?>"/>
             <input name="action" type="hidden" value="mailjet_subscribe_ajax_hook"/>
-            <input name="submit" type="submit" class="mailjet-subscribe" value="<?php echo __($button_text); ?>">
+            <input name="submit" type="submit" class="mailjet-subscribe <?php echo $button_class; ?>"
+                   value="<?php echo __($button_text); ?>">
         </form>
         <div class="response"></div>
         <?php


### PR DESCRIPTION
**Change 1**
When user click in confirmation url show the selected custom page.
Steps:
1- Only create a page
2.- put the custom content and add {{content}} or %content% tags in your custom content
3.- Select this new page in mailjet plugin options.

**Change 2**
:tada: add custom css class to submit button
Add field in widget options to set custom css class to submit button

not only blank page with message.
![mailjet_custom-page](https://cloud.githubusercontent.com/assets/4504113/16172385/53089f22-354d-11e6-9ae5-48d1857fba19.jpg)
