### PR TITLE
Bugfix for "Function name must be a string" when subscribing

### DIFF
--- a/mailjet-widget.php
+++ b/mailjet-widget.php
@@ -500,8 +500,9 @@ class WP_Mailjet_Subscribe_Widget extends WP_Widget
                         continue;
                     }
 
+                    $dataTypeFunction = $dataTypes[$accountProperty->Datatype];
                     if ($accountProperty->Name === $submittedProperty &&
-                        $this->$dataTypes[$accountProperty->Datatype]($_POST[$submittedProperty]) !== true) {
+                        $this->$dataTypeFunction($_POST[$submittedProperty]) !== true) {
                         $error = 'You have entered a contact property with wrong data type, for example a string instead of a number.';
                     }
 


### PR DESCRIPTION
fixed the following error when using a property with type int in the widget:

[04-Mar-2018 10:25:39 UTC] PHP Notice:  Array to string conversion in /wwwdev/wp-content/plugins/mailjet-for-wordpress/mailjet-widget.php on line 504
[04-Mar-2018 10:25:39 UTC] PHP Stack trace:
[04-Mar-2018 10:25:39 UTC] PHP   1. {main}() /wwwdev/wp-admin/admin-ajax.php:0
[04-Mar-2018 10:25:39 UTC] PHP   2. do_action() /wwwdev/wp-admin/admin-ajax.php:112
[04-Mar-2018 10:25:39 UTC] PHP   3. WP_Hook->do_action() /wwwdev/wp-includes/plugin.php:453
[04-Mar-2018 10:25:39 UTC] PHP   4. WP_Hook->apply_filters() /wwwdev/wp-includes/class-wp-hook.php:310
[04-Mar-2018 10:25:39 UTC] PHP   5. WP_Mailjet_Subscribe_Widget->mailjet_subscribe_from_widget() /wwwdev/wp-includes/class-wp-hook.php:286
[04-Mar-2018 10:25:39 UTC] PHP Notice:  Undefined property: WP_Mailjet_Subscribe_Widget::$Array in /wwwdev/wp-content/plugins/mailjet-for-wordpress/mailjet-widget.php on line 504
[04-Mar-2018 10:25:39 UTC] PHP Stack trace:
[04-Mar-2018 10:25:39 UTC] PHP   1. {main}() /wwwdev/wp-admin/admin-ajax.php:0
[04-Mar-2018 10:25:39 UTC] PHP   2. do_action() /wwwdev/wp-admin/admin-ajax.php:112
[04-Mar-2018 10:25:39 UTC] PHP   3. WP_Hook->do_action() /wwwdev/wp-includes/plugin.php:453
[04-Mar-2018 10:25:39 UTC] PHP   4. WP_Hook->apply_filters() /wwwdev/wp-includes/class-wp-hook.php:310
[04-Mar-2018 10:25:39 UTC] PHP   5. WP_Mailjet_Subscribe_Widget->mailjet_subscribe_from_widget() /wwwdev/wp-includes/class-wp-hook.php:286
[04-Mar-2018 10:25:39 UTC] PHP Fatal error:  Uncaught Error: Function name must be a string in /wwwdev/wp-content/plugins/mailjet-for-wordpress/mailjet-widget.php:504
Stack trace:
#0 /wwwdev/wp-includes/class-wp-hook.php(286): WP_Mailjet_Subscribe_Widget->mailjet_subscribe_from_widget('')
#1 /wwwdev/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#2 /wwwdev/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#3 /wwwdev/wp-admin/admin-ajax.php(112): do_action('wp_ajax_nopriv_...')
#4 {main}
  thrown in /wwwdev/wp-content/plugins/mailjet-for-wordpress/mailjet-widget.php on line 504