### PR TITLE
Use the name label defined in ContactForm7 as property in Mailjet

### DIFF
--- a/src/includes/MailjetSettings.php
+++ b/src/includes/MailjetSettings.php
@@ -234,8 +234,15 @@ class MailjetSettings
 
             $contact = array();
             $contact['Email'] = $email;
-            $contact['Properties']['name'] = $name;
-            MailjetApi::createMailjetContactProperty('name');
+
+            // Get the name of the input field that we expect to find in the CF7 form
+            $cf7name = stripslashes(get_option('cf7_fromname', ''));
+            // Remove any character that isn't A-Z, a-z or 0-9 or _ (so it's compatible with Mailjet's properties requirements)
+            $cf7name_clean = preg_replace("/[^A-Za-z0-9_]/", '', $cf7name);
+
+            // And use this input field name to create a property that will contain the subscriber's name
+            $contact['Properties'][$cf7name_clean] = $name;
+            MailjetApi::createMailjetContactProperty($cf7name_clean);
             $syncSingleContactEmailToMailjetList = MailjetApi::syncMailjetContact($contactListId, $contact);
             if (false === $syncSingleContactEmailToMailjetList) {
                 echo $technicalIssue;


### PR DESCRIPTION
Ce changement permet de préciser un nom de propriété personnalisé, pour y stocker le nom/prénom de l'utilisateur.

La raison pour laquelle ce changement est nécessaire est qu'il n'y a aucune raison valide de forcer le nom de la propriété en "name" dans la mailing list sur le site Mailjet.

Il est tout a fait normal que dans le formulaire Contact Form 7, on demande a l'utilisateur de rentrer son prénom, et qu'on veut sauvegarder cette valeur dans une propriété appelée "firstname" et non pas "name".