### PR TITLE
Added apply_filters to allow hooks to edit the Contacts Properties

### DIFF
--- a/src/includes/SettingsPages/SubscriptionOptionsSettings.php
+++ b/src/includes/SettingsPages/SubscriptionOptionsSettings.php
@@ -245,6 +245,9 @@ class SubscriptionOptionsSettings
             );
         }
 
+        // Add apply_filters to allow hooks to edit the contacts value if needed
+        $contacts = apply_filters('mailjet_syncContactsToMailjetList_contacts', $contacts);
+
         return MailjetApi::syncMailjetContacts($contactListId, $contacts, $action);
     }
 
@@ -258,6 +261,9 @@ class SubscriptionOptionsSettings
         $contact = [];
         $contact['Email'] = $email;
         $contact['Properties'] = $contactProperties;
+
+        // Add apply_filters to allow hooks to edit the contact value if needed
+        $contact = apply_filters('mailjet_syncSingleContactEmailToMailjetList_contact', $contact);
 
         return MailjetApi::syncMailjetContact($contactListId, $contact, $action);
     }


### PR DESCRIPTION
Hi,

In this PR, I've added two `apply_filters` to allow hooks from other plugins.

Those `apply_filters` are needed by the plugin that I've created, called [SWPM Mailjet Integration](https://github.com/Th0masL/swpm-mailjet-integration), that allow to use Mailjet with a membership plugin called [Simple WordPress Membership](https://simple-membership-plugin.com/) plugin.

The guys from Simple WordPress Membership plugin have already accepted the PR that was needed to be able to hook Mailjet to their forms, so this PR is the only thing missing to be able to use the Mailjet plugin with Simple WordPress Membership.

This PR is basically a to follow up with the [issue I opened earlier this week](https://github.com/mailjet/wordpress-mailjet-plugin-apiv3/issues/286), where I was explaining that I wanted to add some flexibility to be able to customize the Contact Properties before sending the values to Mailjet's website.

Those `apply_filters` are a transparent change, in a sense that it will not impact anyone, unless they install a plugin that is using those `apply_filters` hooks, like the one I've created.

Let me know if you have any questions.

Thanks

Thomas

