### PR TITLE
load front script in footer

### DIFF
--- a/src/widget/WP_Mailjet_Subscribe_Widget.php
+++ b/src/widget/WP_Mailjet_Subscribe_Widget.php
@@ -1009,7 +1009,7 @@ class WP_Mailjet_Subscribe_Widget extends \WP_Widget
     public function register_widget_front_scripts()
     {
         wp_enqueue_script( 'jquery' );
-        wp_register_script($this->get_widget_slug() . '-front-script', plugins_url('js/front-widget.js', __FILE__));
+        wp_register_script($this->get_widget_slug() . '-front-script', plugins_url('js/front-widget.js', __FILE__), array('jquery'), false, true);
         wp_localize_script($this->get_widget_slug() . '-front-script', 'mjWidget', array('ajax_url' => admin_url('admin-ajax.php')));
         wp_enqueue_script($this->get_widget_slug() . '-front-script');
         wp_enqueue_style($this->get_widget_slug() . '-widget-front-styles', plugins_url('css/front-widget.css', __FILE__));


### PR DESCRIPTION
load front script in footer, avoid load before jQuery in many theme and improve performance