### PR TITLE
Translation file / string not working. Mailjet - Wordpress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 - Contributors: Mailjet
 - Tags: email, marketing, signup, newsletter, widget, smtp, woocommerce, contact form 7
 - Requires at least: 4.4
-- Tested up to: 5.7.2
-- Stable tag: 5.2.17
+- Tested up to: 6.0
+- Stable tag: 5.2.18
 - Requires PHP: 5.6
 - License: GPLv2 or later
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -205,6 +205,9 @@ find vendor/ -type d -name ".git" -exec rm -rf {} \;
 7. Configure abandoned cart notifications for WooCommerce
 
 ## Changelog
+
+##### 5.2.18
+* Fixed issue with not translated string. Some code did not respect the domain of translations
 
 ##### 5.2.16
 * Fixed issue with sending subscribed contact to selected mail list

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - Tags: email, marketing, signup, newsletter, widget, smtp, woocommerce, contact form 7
 - Requires at least: 4.4
 - Tested up to: 6.0
-- Stable tag: 5.2.18
+- Stable tag: 5.2.19
 - Requires PHP: 5.6
 - License: GPLv2 or later
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -206,7 +206,7 @@ find vendor/ -type d -name ".git" -exec rm -rf {} \;
 
 ## Changelog
 
-##### 5.2.18
+##### 5.2.19
 * Fixed issue with not translated string. Some code did not respect the domain of translations
 
 ##### 5.2.16

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Contributors: Mailjet
 Tags: email, marketing, signup, newsletter, widget, smtp, woocommerce, contact form 7
 Requires at least: 4.4
 Tested up to: 6.0
-Stable tag: 5.2.16
+Stable tag: 5.2.18
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -196,6 +196,9 @@ find vendor/ -type d -name ".git" -exec rm -rf {} \;
 7. Configure abandoned cart notifications for WooCommerce
 
 == Upgrade notice ==
+= 5.2.18 =
+* Fixed issue with not translated string. Some code did not respect the domain of translations
+
 = 5.2.16 =
 * Fixed issue with sending subscribed contact to selected mail list
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Contributors: Mailjet
 Tags: email, marketing, signup, newsletter, widget, smtp, woocommerce, contact form 7
 Requires at least: 4.4
 Tested up to: 6.0
-Stable tag: 5.2.18
+Stable tag: 5.2.19
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -196,7 +196,7 @@ find vendor/ -type d -name ".git" -exec rm -rf {} \;
 7. Configure abandoned cart notifications for WooCommerce
 
 == Upgrade notice ==
-= 5.2.18 =
+= 5.2.19 =
 * Fixed issue with not translated string. Some code did not respect the domain of translations
 
 = 5.2.16 =

--- a/src/includes/Mailjet.php
+++ b/src/includes/Mailjet.php
@@ -67,7 +67,7 @@ class Mailjet
         if (defined('MAILJET_VERSION')) {
             $this->version = MAILJET_VERSION;
         } else {
-            $this->version = '5.2.18';
+            $this->version = '5.2.19';
         }
         $this->plugin_name = 'mailjet';
 

--- a/src/includes/Mailjet.php
+++ b/src/includes/Mailjet.php
@@ -67,7 +67,7 @@ class Mailjet
         if (defined('MAILJET_VERSION')) {
             $this->version = MAILJET_VERSION;
         } else {
-            $this->version = '5.2.17';
+            $this->version = '5.2.18';
         }
         $this->plugin_name = 'mailjet';
 

--- a/src/includes/SettingsPages/WooCommerceSettings.php
+++ b/src/includes/SettingsPages/WooCommerceSettings.php
@@ -243,7 +243,7 @@ class WooCommerceSettings
             if (!$contactAlreadySubscribedToList) {
                 $subscribe = get_post_meta($order->get_id(), 'mailjet_woo_subscribe_ok', true);
                 if ((int)$subscribe === 1) {
-                    $str .= ' <br /><br /><i><b>' . __('We have sent the newsletter subscription confirmation link to you: ') . '<b>' . $order->get_billing_email() . '</b>. ' . __('To confirm your subscription you have to click on the provided link.') . '</i></b>';
+                    $str .= ' <br /><br /><i><b>' . __('We have sent the newsletter subscription confirmation link to you: ', 'mailjet-for-wordpress') . '<b>' . $order->get_billing_email() . '</b>. ' . __('To confirm your subscription you have to click on the provided link.', 'mailjet-for-wordpress') . '</i></b>';
                 } elseif (get_option('mailjet_woo_banner_checkbox') === '1') {
                     $str .= $this->addThankYouSubscription($order);
                 }
@@ -358,7 +358,7 @@ class WooCommerceSettings
             if (get_option('mailjet_woo_edata_sync') !== '1') {
                 if ($this->all_customers_edata_sync() === false) {
                     $result['success'] = false;
-                    $result['message'] = __('An error occured during e-commerce data sync! Please try again later.');
+                    $result['message'] = __('An error occured during e-commerce data sync! Please try again later.', 'mailjet-for-wordpress');
                     return $result;
                 }
             }
@@ -388,7 +388,7 @@ class WooCommerceSettings
         if ($activate) {
             if ($this->createTemplates() === false) {
                 $result['success'] = false;
-                $result['message'] = __('An error occured during templates creation! Please try again later.');
+                $result['message'] = __('An error occured during templates creation! Please try again later.', 'mailjet-for-wordpress');
                 return $result;
             }
 
@@ -1091,8 +1091,8 @@ class WooCommerceSettings
        }
 
        if ($this->mailjet_subscribe_confirmation_from_woo_form(1, $email, $fName, $lName)){
-           $message = __('We have sent the newsletter subscription confirmation link to you: ') . $email . '. '
-               . __('To confirm your subscription you have to click on the provided link.');
+           $message = __('We have sent the newsletter subscription confirmation link to you: ', 'mailjet-for-wordpress') . $email . '. '
+               . __('To confirm your subscription you have to click on the provided link.', 'mailjet-for-wordpress');
            return ['success' => true, 'message' => $message];
        }
 
@@ -1206,27 +1206,27 @@ class WooCommerceSettings
         $newSegments = array(
             'Newcomers' => array(
                 'expr' => '(IsInPreviousDays(' . self::WOO_PROP_ACCOUNT_CREATION_DATE . ',30))',
-                'description' => __('Customers who have created an account in the past 30 days')
+                'description' => __('Customers who have created an account in the past 30 days', 'mailjet-for-wordpress')
             ),
             'Potential customers' => array(
                 'expr' => '(' . self::WOO_PROP_TOTAL_ORDERS . '<1)',
-                'description' => __('Contacts that don\'t have any orders')
+                'description' => __('Contacts that don\'t have any orders', 'mailjet-for-wordpress')
             ),
             'First time customers' => array(
                 'expr' => '(' . self::WOO_PROP_TOTAL_ORDERS . '=1) and (IsInPreviousDays(' . self::WOO_PROP_LAST_ORDER_DATE . ',30))',
-                'description' => __('Customers who have made their first purchase in the past 30 days')
+                'description' => __('Customers who have made their first purchase in the past 30 days', 'mailjet-for-wordpress')
             ),
             'Recent customers' => array(
                 'expr' => '(IsInPreviousDays(' . self::WOO_PROP_LAST_ORDER_DATE . ',30))',
-                'description' => __('Customers who have purchased in the past 30 days')
+                'description' => __('Customers who have purchased in the past 30 days', 'mailjet-for-wordpress')
             ),
             'Repeat customers' => array(
                 'expr' => '(' . self::WOO_PROP_TOTAL_ORDERS . '>1)',
-                'description' => __('Customers who have purchased more than once')
+                'description' => __('Customers who have purchased more than once', 'mailjet-for-wordpress')
             ),
             'Lapsed customers' => array(
                 'expr' => '(not IsInPreviousDays(' . self::WOO_PROP_LAST_ORDER_DATE . ',180))',
-                'description' => __('Customers who haven\'t purchased in the past 6 months')
+                'description' => __('Customers who haven\'t purchased in the past 6 months', 'mailjet-for-wordpress')
             )
         );
         foreach ($segments as $seg) {

--- a/wp-mailjet.php
+++ b/wp-mailjet.php
@@ -14,7 +14,7 @@ namespace MailjetPlugin;
  * Plugin Name:       Mailjet for WordPress
  * Plugin URI:        https://www.mailjet.com/partners/wordpress/
  * Description:       The Best WordPress Plugin For Email Newsletters.
- * Version:           5.2.17
+ * Version:           5.2.18
  * Author:            Mailjet SAS
  * Author URI:        http://mailjet.com
  * License:           GPL-2.0+
@@ -54,7 +54,7 @@ use MailjetPlugin\Includes\MailjetActivator;
 /**
  * Mailjet plugin version.
  */
-define('MAILJET_VERSION', '5.2.17');
+define('MAILJET_VERSION', '5.2.18');
 
 /**
  * Mailjet Plugid dir.

--- a/wp-mailjet.php
+++ b/wp-mailjet.php
@@ -14,7 +14,7 @@ namespace MailjetPlugin;
  * Plugin Name:       Mailjet for WordPress
  * Plugin URI:        https://www.mailjet.com/partners/wordpress/
  * Description:       The Best WordPress Plugin For Email Newsletters.
- * Version:           5.2.18
+ * Version:           5.2.19
  * Author:            Mailjet SAS
  * Author URI:        http://mailjet.com
  * License:           GPL-2.0+
@@ -54,7 +54,7 @@ use MailjetPlugin\Includes\MailjetActivator;
 /**
  * Mailjet plugin version.
  */
-define('MAILJET_VERSION', '5.2.18');
+define('MAILJET_VERSION', '5.2.19');
 
 /**
  * Mailjet Plugid dir.


### PR DESCRIPTION
## Description
 - Some code did not respect the `domain` for transactions and instead of using file with plugin translation it took it from `default` domain