### PR TITLE
fix: include Mailjet public class

### DIFF
--- a/src/front/MailjetPublic.php
+++ b/src/front/MailjetPublic.php
@@ -2,6 +2,8 @@
 
 namespace MailjetWp\MailjetPlugin\Front;
 
+use MailjetWp\MailjetPlugin\Includes\Mailjet;
+
 /**
  * The public-facing functionality of the plugin.
  *


### PR DESCRIPTION
Fix https://github.com/mailjet/wordpress-mailjet-plugin-apiv3/issues/373